### PR TITLE
Parameter Order Fixes & DLL/SO Building

### DIFF
--- a/CNFA.c
+++ b/CNFA.c
@@ -49,7 +49,7 @@ void RegCNFADriver( int priority, const char * name, CNFAInitFn * fn )
 }
 
 struct CNFADriver * CNFAInit( const char * driver_name, const char * your_name, CNFACBType cb, int reqSPSPlay, int reqSPSRec,
-	int reqChannelsPlay, int reqChannelsRec, int sugBufferSize, const char * inputSelect, const char * outputSelect, void * opaque)
+	int reqChannelsPlay, int reqChannelsRec, int sugBufferSize, const char * outputSelect, const char * inputSelect, void * opaque)
 {
 
 #if defined( ANDROID ) || defined( __android__ )

--- a/CNFA.h
+++ b/CNFA.h
@@ -38,7 +38,7 @@ extern "C" {
 //I.e. if `out` is null, only use in to read.  If in is null, only place samples in out.
 typedef void(*CNFACBType)( struct CNFADriver * sd, short * in, short * out, int framesr, int framesp );
 
-typedef void*(CNFAInitFn)( CNFACBType cb, const char * your_name, int reqSPSPlay, int reqSPSRec, int reqChannelsPlay, int reqChannelsRec, int sugBufferSize, const char * inputSelect, const char * outputSelect, void * opaque );
+typedef void*(CNFAInitFn)( CNFACBType cb, const char * your_name, int reqSPSPlay, int reqSPSRec, int reqChannelsPlay, int reqChannelsRec, int sugBufferSize, const char * outputSelect, const char * inputSelect, void * opaque );
 
 struct CNFADriver
 {

--- a/CNFA.h
+++ b/CNFA.h
@@ -24,6 +24,16 @@ struct CNFADriver;
 extern "C" {
 #endif
 
+#ifdef BUILD_DLL
+	#ifdef WINDOWS
+		#define DllExport __declspec( dllexport )
+	#else
+		#define DllExport extern
+	#endif
+#else
+	#define DllExport
+#endif
+
 //NOTE: Some drivers have synchronous duplex mode, other drivers will use two different callbacks.  If ether is unavailable, it will be NULL.
 //I.e. if `out` is null, only use in to read.  If in is null, only place samples in out.
 typedef void(*CNFACBType)( struct CNFADriver * sd, short * in, short * out, int framesr, int framesp );
@@ -57,11 +67,11 @@ struct CNFADriver
 // outputSelect = No standardization, NULL is OK for default.
 // inputSelect = No standardization, NULL is OK for default.
 
-struct CNFADriver * CNFAInit( const char * driver_name, const char * your_name, CNFACBType cb, int reqSPSPlay, int reqSPSRec, int reqChannelsPlay,
+DllExport struct CNFADriver * CNFAInit( const char * driver_name, const char * your_name, CNFACBType cb, int reqSPSPlay, int reqSPSRec, int reqChannelsPlay,
 	int reqChannelsRec, int sugBufferSize, const char * outputSelect, const char * inputSelect, void * opaque );
 	
-int CNFAState( struct CNFADriver * cnfaobject ); //returns bitmask.  1 if mic recording, 2 if play back running, 3 if both running.
-void CNFAClose( struct CNFADriver * cnfaobject );
+DllExport int CNFAState( struct CNFADriver * cnfaobject ); //returns bitmask.  1 if mic recording, 2 if play back running, 3 if both running.
+DllExport void CNFAClose( struct CNFADriver * cnfaobject );
 
 
 //Called by various sound drivers.  Notice priority must be greater than 0.  Priority of 0 or less will not register.

--- a/CNFA_pulse.c
+++ b/CNFA_pulse.c
@@ -182,7 +182,7 @@ void * InitCNFAPulse( CNFACBType cb, const char * your_name, int reqSPSPlay, int
 	r->rec = 0;
 	r->buffer = sugBufferSize;
 
-	printf ("Pulse: from: %s/%s (%s) / (%d,%d)x(%d,%d) (%d)\n", r->sourceNameRec, r->sourceNamePlay, title, r->spsPlay, r->spsRec, r->channelsPlay, r->channelsRec, r->buffer );
+	printf ("Pulse: from: [I/O] %s/%s (%s) / (%d,%d)x(%d,%d) (%d)\n", r->sourceNamePlay, r->sourceNameRec, title, r->spsPlay, r->spsRec, r->channelsPlay, r->channelsRec, r->buffer );
 
 	memset( &ss, 0, sizeof( ss ) );
 
@@ -217,7 +217,7 @@ void * InitCNFAPulse( CNFACBType cb, const char * your_name, int reqSPSPlay, int
 		bufattr.minreq = 0;
 		bufattr.prebuf =  (uint32_t)-1;
 		bufattr.tlength = bufbytes*3;
-		int ret = pa_stream_connect_playback(r->play, r->sourceNameRec, &bufattr,
+		int ret = pa_stream_connect_playback(r->play, r->sourceNamePlay, &bufattr,
 				                    // PA_STREAM_INTERPOLATE_TIMING
 				                    // |PA_STREAM_ADJUST_LATENCY //Some servers don't like the adjust_latency flag.
 				                    // |PA_STREAM_AUTO_TIMING_UPDATE, NULL, NULL);
@@ -248,7 +248,7 @@ void * InitCNFAPulse( CNFACBType cb, const char * your_name, int reqSPSPlay, int
 		bufattr.minreq = bufbytes;
 		bufattr.prebuf = (uint32_t)-1;
 		bufattr.tlength = bufbytes*3;
-		int ret = pa_stream_connect_record(r->rec, r->sourceNamePlay, &bufattr, 
+		int ret = pa_stream_connect_record(r->rec, r->sourceNameRec, &bufattr, 
 //							       PA_STREAM_INTERPOLATE_TIMING
 			                       PA_STREAM_ADJUST_LATENCY  //Some servers don't like the adjust_latency flag.
 //		                     	PA_STREAM_AUTO_TIMING_UPDATE

--- a/CNFA_pulse.c
+++ b/CNFA_pulse.c
@@ -182,7 +182,7 @@ void * InitCNFAPulse( CNFACBType cb, const char * your_name, int reqSPSPlay, int
 	r->rec = 0;
 	r->buffer = sugBufferSize;
 
-	printf ("Pulse: from: [I/O] %s/%s (%s) / (%d,%d)x(%d,%d) (%d)\n", r->sourceNamePlay, r->sourceNameRec, title, r->spsPlay, r->spsRec, r->channelsPlay, r->channelsRec, r->buffer );
+	printf ("Pulse: from: [O/I] %s/%s (%s) / (%d,%d)x(%d,%d) (%d)\n", r->sourceNamePlay, r->sourceNameRec, title, r->spsPlay, r->spsRec, r->channelsPlay, r->channelsRec, r->buffer );
 
 	memset( &ss, 0, sizeof( ss ) );
 

--- a/CNFA_wasapi.c
+++ b/CNFA_wasapi.c
@@ -132,8 +132,14 @@ static struct CNFADriverWASAPI* StartWASAPIDriver(struct CNFADriverWASAPI* initS
 	WASAPIState->SessionID = &CNFA_GUID;
 
 	HRESULT ErrorCode;
-	ErrorCode = CoInitialize(NULL); // TODO: Consider using CoInitializeEx if needed for threading.
+	#ifndef BUILD_DLL
+	// A library should never call CoInitialize, as it needs to be done from the host program according to its threading model needs.
+	// NOTE: If you are getting errors, and you are using CNFA as a DLL, you need to call CoInitialize yourself with an appropriate threading model for your needs!
+	// When the host program is something like ColorChord on the other hand, it cannot be expected to call CoInitialize itself, so we do it on its behalf.
+	//   This restricts the threading model of direct consumers of CNFA, but we can address that if it does ever become an issue.
+	ErrorCode = CoInitialize(NULL);
 	if (FAILED(ErrorCode)) { WASAPIERROR(ErrorCode, "COM INIT FAILED!"); return WASAPIState; }
+	#endif
 
 	if(WASAPI_EXTRA_DEBUG)
 	{

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,20 @@
+.PHONY: all shared shared-example clean
+
 all : example
 
 os_generic.h :
 	wget https://raw.githubusercontent.com/cntools/rawdraw/master/os_generic.h
 
 example : example.c os_generic.h
-	gcc -o $@ $^ -lpulse -lasound -lpthread -lm
+	$(CC) -o $@ $^ -lpulse -lasound -lpthread -lm
+
+shared : os_generic.h
+	$(CC) CNFA.c -shared -fpic -o libCNFA.so -DCNFA_IMPLEMENTATION -DBUILD_DLL \
+		-lasound -lpulse -lpthread
+
+shared-example : example.c shared
+	$(CC) -L. -Wl,-rpath=. -o example example.c -DUSE_SHARED -lm -lCNFA
 
 clean :
-	rm -rf *.o *~ example
+	rm -rf *.o *~ example libCNFA.so
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This repo does not contain any tests or building, as this is intended as a libra
 
 
 ### Building .DLL and .SO files
-If you would like to use CNFA in a project where using a DLL or SO file is more practical, you can easily build those files. The below steps assume you are using the Clang compiler. (TCC and others should work fine as well, just have not been tested)
+If you would like to use CNFA in a project where using a DLL or SO file is more practical, you can easily build those files. The below steps are for the Clang & GGC compilers, but others like TCC should work fine as well, just have not been tested.
 
 NOTE: In order for functions to be exported, you'll need to make sure `-DBUILD_DLL` is specified!
 

--- a/README.md
+++ b/README.md
@@ -63,3 +63,8 @@ project to link against it. You can run the example project with `./example`.
 The makefile will try and copy the `os_generic.h` header from 
 [rawdraw](https://github.com/cntools/rawdraw) 
 automatically using `wget`.
+
+The command to build simply build the shared library is:
+```Bash
+gcc CNFA.c -shared -fpic -o CNFA.so -DCNFA_IMPLEMENTATION -DBUILD_DLL -I"[RAWDRAW PATH]" -lasound -lpulse -lpthread
+```

--- a/README.md
+++ b/README.md
@@ -7,17 +7,29 @@ This toolset is 100% based around sound callbacks.
 
 You get three functions:
 
-```
-struct CNFADriver * CNFAInit( const char * driver_name, const char * your_name, CNFACBType cb, int reqSPS, int reqChannelsRec,
-	int reqChannelsPlay, int sugBufferSize, const char * inputSelect, const char * outputSelect, void * opaque )	
-int CNFAState( struct CNFADriver * cnfaobject ); //returns bitmask.  1 if mic recording, 2 if play back running, 3 if both running.
-void CNFAClose( struct CNFADriver * cnfaobject );
+```C
+struct CNFADriver* CNFAInit(const char* driver_name,
+                            const char* your_name,
+                            CNFACBType cb,
+                            int reqSPSPlay,
+                            int reqSPSRec,
+                            int reqChannelsPlay,
+                            int reqChannelsRec,
+                            int sugBufferSize,
+                            const char* outputSelect,
+                            const char* inputSelect,
+                            void* opaque)
+
+// Returns bitmask: 1 if mic recording, 2 if playback running, 3 if both running.
+int CNFAState(struct CNFADriver* cnfaobject)
+
+void CNFAClose(struct CNFADriver* cnfaobject)
 ```
 
 Then it goes and calls a callback function, the `CNFACBType cb` parameter.  This can feed you new frames, or you can pass frames back in.
 
-```
-void Callback( struct CNFADriver * sd, short * in, short * out, int framesr, int framesp )
+```C
+void Callback(struct CNFADriver* sd, short* in, short* out, int framesr, int framesp)
 {
   int i;
   for( i = 0; i < framesr * sd->channelsRec; i++ ) 
@@ -29,3 +41,20 @@ void Callback( struct CNFADriver * sd, short * in, short * out, int framesr, int
 
 This repo does not contain any tests or building, as this is intended as a library-only.  For any use, please see colorchord: https://github.com/cnlohr/colorchord
 
+
+### Building .DLL and .SO files
+If you would like to use CNFA in a project where using a DLL or SO file is more practical, you can easily build those files. The below steps assume you are using the Clang compiler. (TCC and others should work fine as well, just have not been tested)
+
+NOTE: In order for functions to be exported, you'll need to make sure `-DBUILD_DLL` is specified!
+
+Parts of CNFA rely on [rawdraw](https://github.com/cntools/rawdraw), so make sure to clone this repo somewhere and insert the path to it in the `[RAWDRAW PATH]` space below:
+
+Windows build:
+```PS
+& "C:\Program Files\LLVM\bin\clang.exe" CNFA.c -shared -o CNFA.dll -DWINDOWS -DCNFA_IMPLEMENTATION -DBUILD_DLL -D_CRT_SECURE_NO_WARNINGS -I"[RAWDRAW PATH]" -lmmdevapi -lavrt -lole32
+```
+
+Linux build:
+```
+
+```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ Windows build:
 ```
 
 Linux build:
-```
-
+```Bash
+gcc CNFA.c -shared -fpic -o CNFA.so -DCNFA_IMPLEMENTATION -DBUILD_DLL -I"[RAWDRAW PATH]" -lasound -lpulse -lpthread -lm -lpulse-simple
 ```

--- a/README.md
+++ b/README.md
@@ -56,5 +56,10 @@ Windows build:
 
 Linux build:
 ```Bash
-gcc CNFA.c -shared -fpic -o CNFA.so -DCNFA_IMPLEMENTATION -DBUILD_DLL -I"[RAWDRAW PATH]" -lasound -lpulse -lpthread -lm -lpulse-simple
+make shared-example
 ```
+This will build the shared library as `libCNFA.so` and will build the example
+project to link against it. You can run the example project with `./example`.
+The makefile will try and copy the `os_generic.h` header from 
+[rawdraw](https://github.com/cntools/rawdraw) 
+automatically using `wget`.

--- a/example.c
+++ b/example.c
@@ -1,7 +1,11 @@
 #include <stdio.h>
 #include <math.h>
 
+// If using the shared library, don't define CNFA_IMPLEMENTATION 
+// (it's already in the library).
+#ifndef USE_SHARED
 #define CNFA_IMPLEMENTATION
+#endif
 #include "CNFA.h"
 
 #define RUNTIME 500000


### PR DESCRIPTION
I finished fixing the parameter orders for recording/playback device selection, as some were missed in the previous rounds.

I also added what is required to build DLL and SO files, and added info in the readme on how to do that. I have tested this myself for both Windows (WASAPI) and Linux (ALSA).

I also did some general readme cleanup and improved formatting for better readability.