### PR TITLE
Fix clang compilation issue.

### DIFF
--- a/CNFA.c
+++ b/CNFA.c
@@ -29,6 +29,8 @@ void RegCNFADriver( int priority, const char * name, CNFAInitFn * fn )
 		return;
 	}
 
+	printf("[CNFA] Registering Driver: %s\n", name);
+
 	for( j = MAX_CNFA_DRIVERS-1; j >= 0; j-- )
 	{
 		//Cruise along, find location to insert

--- a/CNFA.h
+++ b/CNFA.h
@@ -78,7 +78,7 @@ DllExport void CNFAClose( struct CNFADriver * cnfaobject );
 //This is an internal function.  Applications shouldnot call it.
 void RegCNFADriver( int priority, const char * name, CNFAInitFn * fn );
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #define REGISTER_CNFA( cnfadriver, priority, name, function ) \
 	void REGISTER##cnfadriver() { RegCNFADriver( priority, name, function ); }
 #else


### PR DESCRIPTION
I added an explicit rule to prevent clang from using the MSVC case. This pushes clang into gcc compatible code, which uses the constructor attribute to load functions on initialization. I also added a debugging print statement to CNFA so to display the drivers it initialized on startup. I thought this could possibly aide in debugging in the future.