### PR TITLE
Compatibility with VC6.0

### DIFF
--- a/CNFA.h
+++ b/CNFA.h
@@ -97,8 +97,11 @@ void RegCNFADriver( int priority, const char * name, CNFAInitFn * fn );
 #include "CNFA.c"
 #include "CNFA_null.c"
 #if defined(WINDOWS) || defined(WIN32) || defined(WIN64)
-#include "CNFA_winmm.c"
-#include "CNFA_wasapi.c"
+  #include "CNFA_winmm.c"
+  #include <ntverp.h> // This probably won't work on pre-NT systems
+  #if VER_PRODUCTBUILD >= 7601
+    #include "CNFA_wasapi.c"
+  #endif
 #elif defined( ANDROID ) || defined( __android__ )
 #include "CNFA_android.c"
 #elif defined(__NetBSD__) || defined(__sun)


### PR DESCRIPTION
As part of my dumb project to run ColorChord on Windows 2000, compiled with VC6.0, I had to make a few minor tweaks to CNFA.

Notably:
- Only attempt to compile WASAPI support when using Windows SDK >= Windows 7
- Remove unused include and variables in WinMM
- Move variable declarations to top of their scope in WinMM

Overall, minimal changes that should cause no issues elsewhere. I did compile it in normal ColorChord for Windows 10 without issue still.

The only problem I can foresee is compiling on pre-NT (Win 95/98/ME) no longer working, since the version check is NT-specific. I don't expect that's much of a concern, but a workaround would be trivial.