### PR TITLE
Use more environment variables for OS detection

### DIFF
--- a/CNFA.c
+++ b/CNFA.c
@@ -10,8 +10,12 @@
 #include <stdlib.h>
 
 #if defined(_MSC_VER)
-#if defined(WINDOWS) || defined(WIN32)  || defined(WIN64) \
-                     || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 #ifndef strdup
 #define strdup _strdup
 #endif
@@ -56,7 +60,7 @@ struct CNFADriver * CNFAInit( const char * driver_name, const char * your_name, 
 	int reqChannelsPlay, int reqChannelsRec, int sugBufferSize, const char * outputSelect, const char * inputSelect, void * opaque)
 {
 
-#if defined( ANDROID ) || defined( __android__ )
+#if defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 	//Android can't run static-time code.
 	void REGISTERAndroidCNFA();
 	REGISTERAndroidCNFA();

--- a/CNFA.h
+++ b/CNFA.h
@@ -96,17 +96,22 @@ void RegCNFADriver( int priority, const char * name, CNFAInitFn * fn );
 #ifdef CNFA_IMPLEMENTATION
 #include "CNFA.c"
 #include "CNFA_null.c"
-#if defined(WINDOWS) || defined(WIN32) || defined(WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
   #include "CNFA_winmm.c"
   #include <ntverp.h> // This probably won't work on pre-NT systems
   #if VER_PRODUCTBUILD >= 7601
     #include "CNFA_wasapi.c"
   #endif
-#elif defined( ANDROID ) || defined( __android__ )
+#elif defined(__ANDROID__) || defined(__android__) || defined(ANDROID)
 #include "CNFA_android.c"
-#elif defined(__NetBSD__) || defined(__sun)
+#elif defined(__NetBSD__) || defined(__NetBSD) || defined(__sun) || defined(sun)
 #include "CNFA_sun.c"
-#elif defined(__linux__)
+#elif defined(__linux) || defined(__linux__) || defined(linux) || defined(__LINUX__)
 #include "CNFA_alsa.c"
 #if defined(PULSEAUDIO)
 #include "CNFA_pulse.c"

--- a/CNFA_winmm.c
+++ b/CNFA_winmm.c
@@ -10,8 +10,12 @@
 //Include -lwinmm, or, C:/windows/system32/winmm.dll
 
 #if defined(_MSC_VER)
-#if defined(WINDOWS) || defined(WIN32)  || defined(WIN64) \
-                     || defined(_WIN32) || defined(_WIN64)
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__)
 #ifndef strdup
 #define strdup _strdup
 #endif

--- a/example.c
+++ b/example.c
@@ -1,7 +1,12 @@
 #include <stdio.h>
 #include <math.h>
 
-#ifdef WINDOWS
+#if defined(WINDOWS) || defined(__WINDOWS__) || defined(_WINDOWS) \
+                     || defined(WIN32)       || defined(WIN64) \
+                     || defined(_WIN32)      || defined(_WIN64) \
+                     || defined(__WIN32__)   || defined(__CYGWIN__) \
+                     || defined(__MINGW32__) || defined(__MINGW64__) \
+                     || defined(__TOS_WIN__) || defined(_MSC_VER)
 #include <windows.h>
 #define sleep(time_s) Sleep((time_s) * 1000)
 #else


### PR DESCRIPTION
I replaced a ton of preprocessor OS detections with more robust ones. However, I didn't replace all of them, especially where it looked like the author was intentionally not using all possible environment variable names (that they knew of) to detect a certain OS.

As a warning, I've only tested this in a Windows Cygwin environment (by compiling the [Swadge repo](https://github.com/AEFeinstein/Super-2024-Swadge-FW)) so other environments and OSes still need to be tested.